### PR TITLE
Fix verification script try/catch

### DIFF
--- a/site/verificacao.js
+++ b/site/verificacao.js
@@ -408,14 +408,19 @@ document.addEventListener("DOMContentLoaded", () => {
           setStorage("phoneVerified", "true")
           setStorage("registrationStep", "completed")
           setStorage("accessGranted", "true")
-          showCustomAlert("Código inválido ou expirado.", "error")
-          resetVerifyBtn()
+          showSuccessModal()
         } else {
           showCustomAlert("Código inválido ou expirado.", "error")
           resetVerifyBtn()
         }
+      } catch (error) {
+        console.error("Erro na verificação:", error)
+        showCustomAlert("Erro de conexão. Tente novamente.", "error")
+        resetVerifyBtn()
+      }
+    })
+  }
 
-        
   function resetVerifyBtn() {
     if (verifyBtn) {
       verifyBtn.disabled = false


### PR DESCRIPTION
## Summary
- fix missing catch block in verification code
- update logic to show success modal on valid code
- close event listener and if block properly

## Testing
- `node -c site/verificacao.js`

------
https://chatgpt.com/codex/tasks/task_e_684254a5f12c8329bd88173c6f6faa29